### PR TITLE
Figma plugin update to export JSON data

### DIFF
--- a/figma-plugins/icon-export-helper/code.js
+++ b/figma-plugins/icon-export-helper/code.js
@@ -6,8 +6,88 @@ figma.root.appendChild(page);
 const nodes = figma.currentPage.findAll(node => node.name.indexOf('Icon/') === 0 && node.type == 'COMPONENT_SET');
 const newNodes = [];
 const iconData = {};
-let x = 0;
-let y = 0;
+let svgX = 0;
+let svgY = 0;
+let pngX = 0;
+let pngY = 0;
+function exportComponentAsSVG(node, nodeVariant, subFolder) {
+    const nodeInstance = nodeVariant.createInstance();
+    // Position nicely, assuming a 40x40 grid.
+    nodeInstance.x += svgX * 40;
+    nodeInstance.y += svgY * 40;
+    nodeInstance.resize(24, 24);
+    // Finalize name.
+    // "Icon/Bitcoin circle" with variant "Style=Outline" becomes
+    // "outline/bitcoin-circle"
+    let newName = 'svg/' + subFolder + node.name.split('/')[1];
+    newName = newName.toLowerCase().replace(' ', '-');
+    nodeInstance.name = newName;
+    nodeInstance.exportSettings = [
+        {
+            contentsOnly: true,
+            format: 'SVG',
+            suffix: '',
+            svgIdAttribute: false,
+            svgOutlineText: true,
+            svgSimplifyStroke: true
+        }
+    ];
+    // Add instance to our new page.
+    page.appendChild(nodeInstance);
+    // Keep track of instances for selection.
+    newNodes.push(nodeInstance);
+    const iconName = newName.split('/')[2];
+    const folderName = newName.split('/')[1];
+    let iconInfo = iconData[iconName];
+    if (!iconInfo) {
+        iconInfo = {
+            name: node.name.split('/')[1]
+        };
+    }
+    iconInfo[folderName] = true;
+    iconInfo.svg = true;
+    if (node.description) {
+        iconInfo.description = node.description;
+    }
+    iconData[iconName] = iconInfo;
+    svgX++;
+    // Reset the row every 10 icons
+    if (svgX >= 10) {
+        svgX = 0;
+        svgY += 1;
+    }
+}
+function exportComponentAsPNG(node, nodeVariant, subFolder) {
+    const nodeInstance = nodeVariant.createInstance();
+    // Position nicely, assuming a 40x40 grid.
+    nodeInstance.x += (12 + pngX) * 40;
+    nodeInstance.y += pngY * 40;
+    nodeInstance.resize(24, 24);
+    // Finalize name.
+    // "Icon/Bitcoin circle" with variant "Style=Outline" becomes
+    // "outline/bitcoin-circle"
+    let newName = 'png/' + subFolder + node.name.split('/')[1];
+    newName = newName.toLowerCase().replace(' ', '-');
+    nodeInstance.name = newName;
+    nodeInstance.exportSettings = [
+        {
+            contentsOnly: true,
+            format: 'PNG'
+        }
+    ];
+    // Add instance to our new page.
+    page.appendChild(nodeInstance);
+    // Keep track of instances for selection.
+    newNodes.push(nodeInstance);
+    const iconName = newName.split('/')[2];
+    iconData[iconName].png = true;
+    pngX++;
+    // Reset the row every 10 icons
+    if (pngX >= 10) {
+        pngX = 0;
+        pngY += 1;
+    }
+}
 // Create instance of each component and variant
 for (const node of nodes) {
     // Only use components with variants.
@@ -36,49 +116,8 @@ for (const node of nodes) {
                         }
                     }
                     if (exportIcon === true) {
-                        const nodeInstance = nodeVariant.createInstance();
-                        // Position nicely, assuming a 40x40 grid.
-                        nodeInstance.x += x * 40;
-                        nodeInstance.y += y * 40;
-                        // Finalize name.
-                        // "Icon/Bitcoin circle" with variant "Style=Outline" becomes
-                        // "outline/bitcoin-circle"
-                        let newName = subFolder + node.name.split('/')[1];
-                        newName = newName.toLowerCase().replace(' ', '-');
-                        nodeInstance.name = newName;
-                        nodeInstance.exportSettings = [
-                            {
-                                contentsOnly: true,
-                                format: 'SVG',
-                                suffix: '',
-                                svgIdAttribute: false,
-                                svgOutlineText: true,
-                                svgSimplifyStroke: true
-                            }
-                        ];
-                        // Add instance to our new page.
-                        page.appendChild(nodeInstance);
-                        // Keep track of instances for selection.
-                        newNodes.push(nodeInstance);
-                        const iconName = newName.split('/')[1];
-                        const folderName = newName.split('/')[0];
-                        let iconInfo = iconData[iconName];
-                        if (!iconInfo) {
-                            iconInfo = {
-                                name: node.name.split('/')[1]
-                            };
-                        }
-                        iconInfo[folderName] = true;
-                        if (node.description) {
-                            iconInfo.description = node.description;
-                        }
-                        iconData[iconName] = iconInfo;
-                        x++;
-                        // Reset the row every 10 icons
-                        if (x >= 10) {
-                            x = 0;
-                            y += 1;
-                        }
+                        exportComponentAsSVG(node, nodeVariant, subFolder);
+                        exportComponentAsPNG(node, nodeVariant, subFolder);
                     }
                 }
             }
@@ -91,7 +130,7 @@ page.selection = newNodes;
 figma.currentPage = page;
 // Create a text node to store JSON data.
 const textNode = figma.createText();
-textNode.x = 450;
+textNode.x = 1000;
 textNode.resize(1000, 1000);
 figma.loadFontAsync({ family: "Roboto", style: "Regular" }).then(() => {
     textNode.characters = JSON.stringify(iconData);

--- a/figma-plugins/icon-export-helper/code.js
+++ b/figma-plugins/icon-export-helper/code.js
@@ -5,6 +5,7 @@ figma.root.appendChild(page);
 // Get all nodes that are components and begin with "Icon/"
 const nodes = figma.currentPage.findAll(node => node.name.indexOf('Icon/') === 0 && node.type == 'COMPONENT_SET');
 const newNodes = [];
+const iconData = {};
 let x = 0;
 let y = 0;
 // Create instance of each component and variant
@@ -59,6 +60,19 @@ for (const node of nodes) {
                         page.appendChild(nodeInstance);
                         // Keep track of instances for selection.
                         newNodes.push(nodeInstance);
+                        const iconName = newName.split('/')[1];
+                        const folderName = newName.split('/')[0];
+                        let iconInfo = iconData[iconName];
+                        if (!iconInfo) {
+                            iconInfo = {
+                                name: node.name.split('/')[1]
+                            };
+                        }
+                        iconInfo[folderName] = true;
+                        if (node.description) {
+                            iconInfo.description = node.description;
+                        }
+                        iconData[iconName] = iconInfo;
                         x++;
                         // Reset the row every 10 icons
                         if (x >= 10) {
@@ -75,6 +89,13 @@ for (const node of nodes) {
 page.selection = newNodes;
 // Go to our new page.
 figma.currentPage = page;
+// Create a text node to store JSON data.
+const textNode = figma.createText();
+textNode.x = 450;
+textNode.resize(1000, 1000);
+figma.loadFontAsync({ family: "Roboto", style: "Regular" }).then(() => {
+    textNode.characters = JSON.stringify(iconData);
+});
 // Make sure to close the plugin when you're done. Otherwise the plugin will
 // keep running, which shows the cancel button at the bottom of the screen.
 figma.closePlugin();

--- a/figma-plugins/icon-export-helper/code.ts
+++ b/figma-plugins/icon-export-helper/code.ts
@@ -10,8 +10,112 @@ const nodes = figma.currentPage.findAll(node => node.name.indexOf('Icon/') === 0
 const newNodes = []
 const iconData = {}
 
-let x = 0
-let y = 0
+let svgX = 0
+let svgY = 0
+let pngX = 0
+let pngY = 0
+
+function exportComponentAsSVG(node, nodeVariant, subFolder) {
+	const nodeInstance = nodeVariant.createInstance()
+
+	// Position nicely, assuming a 40x40 grid.
+	nodeInstance.x += svgX * 40
+	nodeInstance.y += svgY * 40
+	nodeInstance.resize(24, 24)
+
+	// Finalize name.
+	// "Icon/Bitcoin circle" with variant "Style=Outline" becomes
+	// "outline/bitcoin-circle"
+	let newName = 'svg/' + subFolder + node.name.split('/')[1]
+	newName = newName.toLowerCase().replace(' ', '-')
+	nodeInstance.name = newName
+
+	nodeInstance.exportSettings = [
+		{
+			contentsOnly: true,
+			format: 'SVG',
+			suffix: '',
+			svgIdAttribute: false,
+			svgOutlineText: true,
+			svgSimplifyStroke: true
+		}
+	]
+
+	// Add instance to our new page.
+	page.appendChild(nodeInstance)
+
+	// Keep track of instances for selection.
+	newNodes.push(nodeInstance)
+
+	const iconName = newName.split('/')[2]
+	const folderName = newName.split('/')[1]
+
+	let iconInfo:any = iconData[iconName]
+
+	if(!iconInfo) {
+		iconInfo = {
+			name: node.name.split('/')[1]
+		}
+	}
+
+	iconInfo[folderName] = true
+	iconInfo.svg = true
+
+	if(node.description) {
+		iconInfo.description = node.description
+	}
+
+	iconData[iconName] = iconInfo
+
+	svgX++
+
+	// Reset the row every 10 icons
+	if(svgX >= 10) {
+		svgX = 0
+		svgY += 1
+	}
+}
+
+function exportComponentAsPNG(node, nodeVariant, subFolder) {
+	const nodeInstance = nodeVariant.createInstance()
+
+	// Position nicely, assuming a 40x40 grid.
+	nodeInstance.x += (12 + pngX) * 40
+	nodeInstance.y += pngY * 40
+	nodeInstance.resize(24, 24)
+
+	// Finalize name.
+	// "Icon/Bitcoin circle" with variant "Style=Outline" becomes
+	// "outline/bitcoin-circle"
+	let newName = 'png/' + subFolder + node.name.split('/')[1]
+	newName = newName.toLowerCase().replace(' ', '-')
+	nodeInstance.name = newName
+
+	nodeInstance.exportSettings = [
+		{
+			contentsOnly: true,
+			format: 'PNG'
+		}
+	]
+
+	// Add instance to our new page.
+	page.appendChild(nodeInstance)
+
+	// Keep track of instances for selection.
+	newNodes.push(nodeInstance)
+
+	const iconName = newName.split('/')[2]
+
+	iconData[iconName].png = true
+
+	pngX++
+
+	// Reset the row every 10 icons
+	if(pngX >= 10) {
+		pngX = 0
+		pngY += 1
+	}
+}
 
 // Create instance of each component and variant
 for (const node of nodes) {
@@ -45,62 +149,8 @@ for (const node of nodes) {
 					}
 
 					if(exportIcon === true) {
-						const nodeInstance = nodeVariant.createInstance()
-
-						// Position nicely, assuming a 40x40 grid.
-						nodeInstance.x += x * 40
-						nodeInstance.y += y * 40
-
-						// Finalize name.
-						// "Icon/Bitcoin circle" with variant "Style=Outline" becomes
-						// "outline/bitcoin-circle"
-						let newName = subFolder + node.name.split('/')[1]
-						newName = newName.toLowerCase().replace(' ', '-')
-						nodeInstance.name = newName
-
-						nodeInstance.exportSettings = [
-							{
-								contentsOnly: true,
-								format: 'SVG',
-								suffix: '',
-								svgIdAttribute: false,
-								svgOutlineText: true,
-								svgSimplifyStroke: true
-							}
-						]
-
-						// Add instance to our new page.
-						page.appendChild(nodeInstance)
-
-						// Keep track of instances for selection.
-						newNodes.push(nodeInstance)
-
-						const iconName = newName.split('/')[1]
-						const folderName = newName.split('/')[0]
-
-						let iconInfo:any = iconData[iconName]
-
-						if(!iconInfo) {
-							iconInfo = {
-								name: node.name.split('/')[1]
-							}
-						}
-
-						iconInfo[folderName] = true
-
-						if(node.description) {
-							iconInfo.description = node.description
-						}
-
-						iconData[iconName] = iconInfo
-
-						x++
-
-						// Reset the row every 10 icons
-						if(x >= 10) {
-							x = 0
-							y += 1
-						}
+						exportComponentAsSVG(node, nodeVariant, subFolder)
+						exportComponentAsPNG(node, nodeVariant, subFolder)
 					}
 				}
 			}
@@ -116,7 +166,7 @@ figma.currentPage = page
 
 // Create a text node to store JSON data.
 const textNode = figma.createText()
-textNode.x = 450
+textNode.x = 1000
 textNode.resize(1000, 1000)
 
 figma.loadFontAsync({ family: "Roboto", style: "Regular" }).then(() => {

--- a/figma-plugins/icon-export-helper/code.ts
+++ b/figma-plugins/icon-export-helper/code.ts
@@ -8,6 +8,7 @@ figma.root.appendChild(page);
 const nodes = figma.currentPage.findAll(node => node.name.indexOf('Icon/') === 0 && node.type == 'COMPONENT_SET')
 
 const newNodes = []
+const iconData = {}
 
 let x = 0
 let y = 0
@@ -74,6 +75,25 @@ for (const node of nodes) {
 						// Keep track of instances for selection.
 						newNodes.push(nodeInstance)
 
+						const iconName = newName.split('/')[1]
+						const folderName = newName.split('/')[0]
+
+						let iconInfo:any = iconData[iconName]
+
+						if(!iconInfo) {
+							iconInfo = {
+								name: node.name.split('/')[1]
+							}
+						}
+
+						iconInfo[folderName] = true
+
+						if(node.description) {
+							iconInfo.description = node.description
+						}
+
+						iconData[iconName] = iconInfo
+
 						x++
 
 						// Reset the row every 10 icons
@@ -93,6 +113,15 @@ page.selection = newNodes
 
 // Go to our new page.
 figma.currentPage = page
+
+// Create a text node to store JSON data.
+const textNode = figma.createText()
+textNode.x = 450
+textNode.resize(1000, 1000)
+
+figma.loadFontAsync({ family: "Roboto", style: "Regular" }).then(() => {
+	textNode.characters = JSON.stringify(iconData)
+})
 
 // Make sure to close the plugin when you're done. Otherwise the plugin will
 // keep running, which shows the cancel button at the bottom of the screen.


### PR DESCRIPTION
Adds code to the plugin that gathers icon info in Figma, puts it in an object, stringifies it and shows it as a text field. Idea is that this icon index can be copied and submitted as a JSON file to Github, and then used in a landing page to render icons. This centralizes text info about icons in the Figma file, as the component name and description can be used.

Seems like an easy way to keep things organized.