### PR TITLE
Add raw builds with SVG data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitcoin-design/bitcoin-icons",
-  "version": "0.1.0",
+  "version": "0.1.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitcoin-design/bitcoin-icons",
-      "version": "0.1.0",
+      "version": "0.1.9",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.12.10",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "main": "index.js",
   "scripts": {
     "prepublishOnly": "npm run build",
-    "build": "npm run build-outline && npm run build-filled && npm run build-react && npm run build-vue",
+    "build": "npm run build-outline && npm run build-filled && npm run build-react && npm run build-vue && npm run build-raw",
     "build-react": "node ./scripts/build.js react",
     "build-vue": "node ./scripts/build.js vue",
+    "build-raw": "node ./scripts/build.js raw",
     "build-outline": "rimraf ./outline ./optimized/outline && svgo --config=svgo.outline.yaml -f ./svg/outline -o ./optimized/outline --pretty --indent=2 && cp -R ./optimized/outline ./outline",
     "build-filled": "rimraf ./filled ./optimized/filled && svgo --config=svgo.filled.yaml -f ./svg/filled -o ./optimized/filled --pretty --indent=2 && cp -R ./optimized/filled ./filled"
   },

--- a/raw/.gitignore
+++ b/raw/.gitignore
@@ -1,0 +1,4 @@
+*
+!.gitignore
+!package.json
+!README.md

--- a/raw/README.md
+++ b/raw/README.md
@@ -1,0 +1,35 @@
+# Bitcoin Icons
+
+[![npm version](https://img.shields.io/npm/v/@bitcoin-design/bitcoin-icons-svg.svg?style=flat-square)](https://www.npmjs.com/package/@bitcoin-design/bitcoin-icons-svg)
+[![npm downloads](https://img.shields.io/npm/dm/@bitcoin-design/bitcoin-icons-svg.svg?style=flat-square)](https://www.npmjs.com/package/@bitcoin-design/bitcoin-icons-svg)
+
+Bitcoin Icons is an open-source/open-design set of icons made for Bitcoin centric applications. Included are general icons most applications need like arrows and a home icon, and maybe more importantly Bitcoin-specific icons like a wallet, keys, miner and Bitcoin symbols.
+
+https://bitcoinicons.com
+
+### Installation
+
+First, install `@bitcoin-design/bitcoin-icons-svg` from npm:
+
+```sh
+npm install @bitcoin-design/bitcoin-icons-svg
+```
+
+### Usage
+
+Now each icon can be imported individually
+
+```JavaScript
+import { BitcoinIcon } from '@bitcoin-design/bitcoin-icons-svg/filled'
+
+console.log(BitcoinIcon)
+// ==>
+// {
+//   name: 'bitcoin',
+//   svg: '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">...</svg>'
+// };
+```
+
+The outline icons can be imported from `@bitcoin-design/bitcoin-icons-svg/outline`, and the filled icons can be imported from `@bitcoin-design/bitcoin-icons-svg/filled`.
+
+Icons use an upper camel case naming convention and are always suffixed with the word `Icon`.

--- a/raw/package.json
+++ b/raw/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@bitcoin-design/bitcoin-icons-svg",
+  "version": "0.1.9",
+  "description": "",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/BitcoinDesign/Bitcoin-Icons.git"
+  },
+  "keywords": [
+    "bitcoin",
+    "icons"
+  ],
+  "author": "Bitcoin Design Community",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/BitcoinDesign/Bitcoin-Icons/issues"
+  },
+  "files": [
+    "outline",
+    "filled"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://github.com/BitcoinDesign/Bitcoin-Icons#readme"
+}


### PR DESCRIPTION
These builds would make it easier to use the SVGs, for example for a Figma plugin (#27).

I'll publish a version to the @runcitadel namespace for testing and demonstration purposes soon.
